### PR TITLE
Add option to generate extra labels on series

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -27,6 +27,7 @@ var (
 	queryMaxAge            = kingpin.Flag("query-max-age", "How back in the past metrics can be queried at most.").Default("24h").Duration()
 	tenantsCount           = kingpin.Flag("tenants-count", "Number of tenants to fake.").Default("1").Int()
 	seriesCount            = kingpin.Flag("series-count", "Number of series to generate for each tenant.").Default("1000").Int()
+	extraLabelCount        = kingpin.Flag("extra-labels-count", "Number of extra labels to generate for series.").Default("0").Int()
 	serverMetricsPort      = kingpin.Flag("server-metrics-port", "The port where metrics are exposed.").Default("9900").Int()
 )
 
@@ -64,6 +65,7 @@ func main() {
 			WriteBatchSize:   *remoteBatchSize,
 			UserID:           userID,
 			SeriesCount:      *seriesCount,
+			ExtraLabels:      *extraLabelCount,
 		}, logger))
 
 		if *queryEnabled == "true" {


### PR DESCRIPTION
This is useful if you are investigating the load created by multiple labels in series; by default the series here have only a name and one label.

This PR adds a configurable number of labels `extraLabel0`, `extraLabel1`, etc., all with value `"default"`.  So not particularly interesting, but it provides a little extra stress on the backend.