### PR TITLE
Add optional sawtooth series

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -26,7 +26,8 @@ var (
 	queryTimeout           = kingpin.Flag("query-timeout", "Query timeout.").Default("30s").Duration()
 	queryMaxAge            = kingpin.Flag("query-max-age", "How back in the past metrics can be queried at most.").Default("24h").Duration()
 	tenantsCount           = kingpin.Flag("tenants-count", "Number of tenants to fake.").Default("1").Int()
-	seriesCount            = kingpin.Flag("series-count", "Number of series to generate for each tenant.").Default("1000").Int()
+	seriesCount            = kingpin.Flag("series-count", "Number of sinewave series to generate for each tenant.").Default("1000").Int()
+	sawtoothCount          = kingpin.Flag("sawtooth-count", "Number of sawtooth series to generate for each tenant.").Default("0").Int()
 	extraLabelCount        = kingpin.Flag("extra-labels-count", "Number of extra labels to generate for series.").Default("0").Int()
 	serverMetricsPort      = kingpin.Flag("server-metrics-port", "The port where metrics are exposed.").Default("9900").Int()
 )
@@ -65,6 +66,7 @@ func main() {
 			WriteBatchSize:   *remoteBatchSize,
 			UserID:           userID,
 			SeriesCount:      *seriesCount,
+			SawtoothCount:    *sawtoothCount,
 			ExtraLabels:      *extraLabelCount,
 		}, logger))
 

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -82,7 +82,8 @@ func (c *WriteClient) run() {
 
 func (c *WriteClient) writeSeries() {
 	ts := alignTimestampToInterval(time.Now(), c.cfg.WriteInterval)
-	series := generateSineWaveSeries(ts, c.cfg.SeriesCount, c.cfg.ExtraLabels)
+	value := generateSineWaveValue(ts)
+	series := generateSeries("cortex_load_generator_sine_wave", ts, value, c.cfg.SeriesCount, c.cfg.ExtraLabels)
 
 	// Honor the batch size.
 	wg := sync.WaitGroup{}
@@ -163,14 +164,13 @@ func alignTimestampToInterval(ts time.Time, interval time.Duration) time.Time {
 	return time.Unix(0, (ts.UnixNano()/int64(interval))*int64(interval))
 }
 
-func generateSineWaveSeries(t time.Time, seriesCount, extraLabels int) []*prompb.TimeSeries {
+func generateSeries(name string, t time.Time, value float64, seriesCount, extraLabels int) []*prompb.TimeSeries {
 	out := make([]*prompb.TimeSeries, 0, seriesCount)
-	value := generateSineWaveValue(t)
 
 	for i := 1; i <= seriesCount; i++ {
 		labels := []*prompb.Label{{
 			Name:  "__name__",
-			Value: "cortex_load_generator_sine_wave",
+			Value: name,
 		}, {
 			Name:  "wave",
 			Value: strconv.Itoa(i),


### PR DESCRIPTION
These compress much better in TSDB, more like real-world data.

Queries are still done only on the sine-wave series, so you can
 vary the relative cost of querying by the proportion of sine-wave
 and sawtooth series