### PR TITLE
Configure linter to ignore unused errors returned from logger calls

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,0 +1,1 @@
+(github.com/go-kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  errcheck:
+    # path to a file containing a list of functions to exclude from checking
+    # see https://github.com/kisielk/errcheck#excluding-functions for details
+    exclude: ./.errcheck-exclude

--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -46,7 +46,7 @@ func main() {
 
 	i := util.NewInstrumentationServer(*serverMetricsPort, logger, reg)
 	if err := i.Start(); err != nil {
-		level.Error(logger).Log("msg", "Unable to start instrumentation server", "err", err.Error()) //nolint:errcheck
+		level.Error(logger).Log("msg", "Unable to start instrumentation server", "err", err.Error())
 		os.Exit(1)
 	}
 

--- a/pkg/client/query.go
+++ b/pkg/client/query.go
@@ -125,7 +125,7 @@ func (c *QueryClient) runQueries() {
 	// Compute the query start/end time.
 	start, end, ok := c.getQueryTimeRange(time.Now().UTC())
 	if !ok {
-		level.Debug(c.logger).Log("msg", "skipped querying because no eligible time range to query") //nolint:errcheck
+		level.Debug(c.logger).Log("msg", "skipped querying because no eligible time range to query")
 		c.queriesTotal.WithLabelValues(querySkipped, "").Inc()
 		return
 	}
@@ -162,7 +162,7 @@ func (c *QueryClient) runDefaultQuery(start, end time.Time, step time.Duration) 
 
 	err = verifySineWaveSamples(samples, c.cfg.ExpectedSeries, step)
 	if err != nil {
-		level.Warn(c.logger).Log("msg", "query result comparison failed", "err", err, "query", defaultQuery) //nolint:errcheck
+		level.Warn(c.logger).Log("msg", "query result comparison failed", "err", err, "query", defaultQuery)
 		c.resultsComparedTotal.WithLabelValues(comparisonFailed, defaultQuery).Inc()
 		return
 	}
@@ -177,7 +177,7 @@ func (c *QueryClient) runAdditionalQuery(start, end time.Time, step time.Duratio
 func (c *QueryClient) runQueryAndCollectStats(start, end time.Time, step time.Duration, query string) ([]model.SamplePair, error) {
 	samples, err := c.runQuery(start, end, step, query)
 	if err != nil {
-		level.Error(c.logger).Log("msg", "failed to execute query", "err", err, "query", query) //nolint:errcheck
+		level.Error(c.logger).Log("msg", "failed to execute query", "err", err, "query", query)
 		c.queriesTotal.WithLabelValues(queryFailed, query).Inc()
 	}
 

--- a/pkg/client/write.go
+++ b/pkg/client/write.go
@@ -108,7 +108,7 @@ func (c *WriteClient) writeSeries() {
 
 			err := c.send(ctx, req)
 			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to write series", "err", err) //nolint:errcheck
+				level.Error(c.logger).Log("msg", "failed to write series", "err", err)
 			}
 		}(o)
 	}
@@ -142,7 +142,7 @@ func (c *WriteClient) send(ctx context.Context, req *prompb.WriteRequest) error 
 	if err != nil {
 		return err
 	}
-	defer httpResp.Body.Close() //nolint:errcheck
+	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode/100 != 2 {
 		scanner := bufio.NewScanner(io.LimitReader(httpResp.Body, maxErrMsgLen))

--- a/pkg/util/instrumentation.go
+++ b/pkg/util/instrumentation.go
@@ -45,7 +45,7 @@ func (s *InstrumentationServer) Start() error {
 
 	go func() {
 		if err := s.srv.Serve(listener); err != nil {
-			level.Error(s.logger).Log("msg", "metrics server terminated", "err", err) //nolint:errcheck
+			level.Error(s.logger).Log("msg", "metrics server terminated", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
Context: https://github.com/pracucci/cortex-load-generator/pull/6#discussion_r1239472043